### PR TITLE
Add scroll-mt-12 to section anchors to avoid navbar obscuration

### DIFF
--- a/src/app/SeminarContent.js
+++ b/src/app/SeminarContent.js
@@ -167,7 +167,7 @@ const SeminarContent = () => {
 
       {/* Schedule Component */}
 
-      <section id="program" className="py-4 md:py-6 bg-background">
+      <section id="program" className="py-4 md:py-6 bg-background scroll-mt-12">
         <div className="text-center mb-6">
           <SectionTitle 
             onClick={() => handleToggleSection('program')}
@@ -187,7 +187,7 @@ const SeminarContent = () => {
       </section>
 
       {/* --- SEZIONE ABOUT --- */}
-      <section id="about" className="py-4 md:py-6 bg-background border-t border-border">
+      <section id="about" className="py-4 md:py-6 bg-background border-t border-border scroll-mt-12">
         <div className="text-center mb-6">
           <SectionTitle 
             onClick={() => handleToggleSection('about')}
@@ -204,7 +204,7 @@ const SeminarContent = () => {
       </section>
 
       {/* Research Centers Section */}
-      <section id="research-centers" className="py-4 md:py-6 bg-background border-t border-border">
+      <section id="research-centers" className="py-4 md:py-6 bg-background border-t border-border scroll-mt-12">
         <div className="text-center mb-6">
           <SectionTitle 
             onClick={() => handleToggleSection('researchCenters')}
@@ -220,7 +220,7 @@ const SeminarContent = () => {
       </section>
 
       {/* Organizing Committee Section */}
-      <section id="committee" className="py-4 md:py-6 bg-background border-t border-border">
+      <section id="committee" className="py-4 md:py-6 bg-background border-t border-border scroll-mt-12">
         <div className="text-center mb-6">
           <SectionTitle 
             onClick={() => handleToggleSection('committee')}

--- a/src/app/SeminarContent.js
+++ b/src/app/SeminarContent.js
@@ -37,11 +37,13 @@ const SeminarContent = () => {
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex justify-between items-center h-16">
             <div className="flex items-center space-x-8">
-              <img
-                src={getImagePath("/images/dhlandscapes_logo.svg")}
-                alt="DH Landscapes Logo"
-                className="h-8 w-auto"
-              />
+              <a href="#">
+                <img
+                  src={getImagePath("/images/dhlandscapes_logo.svg")}
+                  alt="DH Landscapes Logo"
+                  className="h-8 w-auto"
+                />
+              </a>
               <div className="hidden md:flex items-center space-x-6">
                 <a
                   href="#program"


### PR DESCRIPTION
Since the site uses a fixed to top navbar, when using classic anchor scrolling to a section id the title of the section is covered by the navbar.

This PR adds a minimal scroll offset to each section id (via tailwind utility `scroll-mt`), preventing the section title from being covered by the fixed navbar.

Before | After
:-----:|:-----:
![](https://github.com/user-attachments/assets/e7981a1d-90b7-4e6f-8473-d5f610618b1d)  |  ![](https://github.com/user-attachments/assets/1f568c43-53a6-46c3-b8d4-1ecc70748595)


I also have added a quick scroll to top fix when clicking the main navbar logo for consistency and removed the empty `Nuovo Documento di testo.txt` in the root folder.